### PR TITLE
Relax dependencies on parallel and deepseq

### DIFF
--- a/vty.cabal
+++ b/vty.cabal
@@ -32,7 +32,7 @@ Build-Depends:       base >= 4 && < 5, ghc-prim, bytestring, containers, unix
 Build-Depends:       terminfo >= 0.3 && < 0.4
 Build-Depends:       utf8-string >= 0.3 && < 0.4
 Build-Depends:       mtl >= 1.1.1.0 && < 2.1
-Build-Depends:       parallel >= 2.2 && < 3.2, deepseq >= 1.1 && < 1.2
+Build-Depends:       parallel >= 2.2 && < 3.3, deepseq >= 1.1 && < 1.3
 Build-Depends:       vector >= 0.7
 Build-Depends:       parsec >= 2 && < 4
 Build-Type:          Simple


### PR DESCRIPTION
Fairly self-explanatory.

The update on deepseq was for the removal of containers instances – which we don't use.
The update on parallel I didn't check carefully, but I don't think it's important – seems to be just an API addition.
