### PR TITLE
Dependency patch makes it build with GHC-7.4.1

### DIFF
--- a/vty.cabal
+++ b/vty.cabal
@@ -1,5 +1,5 @@
 Name:                vty
-Version:             4.7.0.8
+Version:             4.7.0.9
 License:             BSD3
 License-file:        LICENSE
 Author:              Stefan O'Rear, Corey O'Connor
@@ -32,7 +32,7 @@ Build-Depends:       base >= 4 && < 5, ghc-prim, bytestring, containers, unix
 Build-Depends:       terminfo >= 0.3 && < 0.4
 Build-Depends:       utf8-string >= 0.3 && < 0.4
 Build-Depends:       mtl >= 1.1.1.0 && < 2.1
-Build-Depends:       parallel >= 2.2 && < 3.3, deepseq >= 1.1 && < 1.3
+Build-Depends:       parallel >= 2.2 && < 3.3, deepseq >= 1.1 && < 1.4
 Build-Depends:       vector >= 0.7
 Build-Depends:       parsec >= 2 && < 4
 Build-Type:          Simple


### PR DESCRIPTION
This dependency and cautious-file's need to be updated to make Yi-editor build with GHC-7.4.
