### PR TITLE
Export Graphics.Vty.Image module

### DIFF
--- a/vty.cabal
+++ b/vty.cabal
@@ -41,6 +41,7 @@ Exposed-Modules:     Graphics.Vty
                      Graphics.Vty.Terminal
                      Graphics.Vty.LLInput
                      Graphics.Vty.Attributes
+                     Graphics.Vty.Image
                      Graphics.Vty.Inline
                      Graphics.Vty.Picture
                      Graphics.Vty.DisplayRegion
@@ -50,7 +51,6 @@ other-modules:       Codec.Binary.UTF8.Width
                      Data.Terminfo.Parse
                      Data.Terminfo.Eval
                      Graphics.Vty.DisplayAttributes
-                     Graphics.Vty.Image
                      Graphics.Vty.Span
                      Graphics.Vty.Terminal.Generic
                      Graphics.Vty.Terminal.MacOSX


### PR DESCRIPTION
This patch exports the `Graphics.Vty.Image` so I can get access to the character width functions we discussed in https://github.com/jtdaugherty/vty-ui/issues/8.  If this is okay, can you release this change soon?
