### PR TITLE
Escape forward slashes

### DIFF
--- a/vty.cabal
+++ b/vty.cabal
@@ -20,9 +20,9 @@ description:
   Notable infelicities: Sometimes poor efficiency; Assumes UTF-8 character encoding support by the
   terminal;
   .
-  Project is hosted on github.com: https://github.com/coreyoconnor/vty
+  Project is hosted on github.com: https:\/\/github.com\/coreyoconnor\/vty
   .
-  git clone git://github.com/coreyoconnor/vty.git
+  git clone git:\/\/github.com\/coreyoconnor\/vty.git
   .
   &#169; 2006-2007 Stefan O'Rear; BSD3 license.
   .


### PR DESCRIPTION
hackage interprets those slashes as italics, as you can see here:
http://hackage.haskell.org/package/vty

So you need to escape them.
