### PR TITLE
Add ScopedTypeVariables pragma to interactive_terminal_test

### DIFF
--- a/test/interactive_terminal_test.hs
+++ b/test/interactive_terminal_test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Main where
 
 import Graphics.Vty


### PR DESCRIPTION
Otherwise l. 77 (now 78) "_ :: SomeException" doesn't seem to work.

GHC says:
interactive_terminal_test.hs:77:59:
    Illegal type signature: ‘SomeException’
      Perhaps you intended to use ScopedTypeVariables
    In a pattern type-signature
