### PR TITLE
Bump upper version bound for lens to 4.5

### DIFF
--- a/vty.cabal
+++ b/vty.cabal
@@ -50,7 +50,7 @@ library
                        deepseq >= 1.1 && < 1.4,
                        directory,
                        filepath >= 1.0 && < 2.0,
-                       lens >= 3.9.0.2 && < 4.4,
+                       lens >= 3.9.0.2 && < 4.5,
                        -- required for nice installation with yi
                        hashable >= 1.2,
                        mtl >= 1.1.1.0 && < 2.3,


### PR DESCRIPTION
Lens 4.4 drops the dependencies for aeson, attoparsec and scientific.

Release Notes: http://www.reddit.com/r/haskell/comments/2e9918/lens_44_release_notes/

I tested that vty compiles with lens-4.4 which it did but `cabal test` failed with an error:

```
Could not find module ‘Distribution.Simple.Test.LibV09’
Perhaps you meant Distribution.Simple.Test (from Cabal-1.18.1.3)
Use -v to see a list of the files searched for.
```

Which is unrelated to the lens version AFAIK.

Best,
Markus
