### PR TITLE
Bump lens upperbound

### DIFF
--- a/vty.cabal
+++ b/vty.cabal
@@ -50,7 +50,7 @@ library
                        deepseq >= 1.1 && < 1.5,
                        directory,
                        filepath >= 1.0 && < 2.0,
-                       lens >= 3.9.0.2 && < 4.9,
+                       lens >= 3.9.0.2 && < 4.10,
                        -- required for nice installation with yi
                        hashable >= 1.2,
                        mtl >= 1.1.1.0 && < 2.3,


### PR DESCRIPTION
Lens required a major version bump because it dropped a module that vty doesn't use. It would be safe to update vty's lens bound in place on hackage without a bump.