### PR TITLE
Add support for bracketed paste mode in XtermColor-driven terminals (fixes #50)

### DIFF
--- a/src/Graphics/Vty/Input/Classify.hs
+++ b/src/Graphics/Vty/Input/Classify.hs
@@ -13,11 +13,12 @@ module Graphics.Vty.Input.Classify
 
 import Graphics.Vty.Input.Events
 import Graphics.Vty.Input.Mouse
+import Graphics.Vty.Input.Paste
 import Graphics.Vty.Input.Classify.Types
 
 import Codec.Binary.UTF8.Generic (decode)
 
-import Data.List (inits, isPrefixOf, isInfixOf)
+import Data.List (inits)
 import qualified Data.Map as M( fromList, lookup )
 import Data.Maybe ( mapMaybe )
 import qualified Data.Set as S( fromList, member )
@@ -83,31 +84,3 @@ utf8Length c
     | c < 0xE0 = 2
     | c < 0xF0 = 3
     | otherwise = 4
-
-bracketedPasteStart :: String
-bracketedPasteStart = "\ESC[200~"
-
-bracketedPasteEnd :: String
-bracketedPasteEnd = "\ESC[201~"
-
-bracketedPasteStarted :: String -> Bool
-bracketedPasteStarted = isPrefixOf bracketedPasteStart
-
-bracketedPasteFinished :: String -> Bool
-bracketedPasteFinished = isInfixOf bracketedPasteEnd
-
-takeUntil :: (Eq a) => [a] -> [a] -> ([a],[a])
-takeUntil [] _ = ([], [])
-takeUntil cs sub
-  | length cs < length sub      = (cs, [])
-  | take (length sub) cs == sub = ([], drop (length sub) cs)
-  | otherwise                   = let (pre, suf) = takeUntil (tail cs) sub
-                                  in (head cs:pre, suf)
-
-parseBracketedPaste :: String -> KClass
-parseBracketedPaste s =
-    let (p, rest) = takeUntil (drop (length bracketedPasteStart) s) bracketedPasteEnd
-        rest' = if bracketedPasteEnd `isPrefixOf` rest
-                then drop (length bracketedPasteEnd) rest
-                else rest
-    in Valid (EvPaste p) rest'

--- a/src/Graphics/Vty/Input/Events.hs
+++ b/src/Graphics/Vty/Input/Events.hs
@@ -36,6 +36,12 @@ data Event
     -- 'nextEvent' this is the size at the time the event was processed by Vty. Typically these are
     -- the same, but if somebody is resizing the terminal quickly they can be different.
     | EvResize Int Int
+    | EvPaste String
+    -- ^ A paste event occurs when a bracketed paste input sequence is
+    -- received. For terminals that support bracketed paste mode, these
+    -- events will be triggered on a paste event. Terminals that do not
+    -- support bracketed pastes will send the paste contents as ordinary
+    -- input (which is probably bad, so beware!)
     deriving (Eq,Show,Read,Ord)
 
 type ClassifyMap = [(String,Event)]

--- a/src/Graphics/Vty/Input/Mouse.hs
+++ b/src/Graphics/Vty/Input/Mouse.hs
@@ -13,7 +13,6 @@ import Graphics.Vty.Input.Events
 import Graphics.Vty.Input.Classify.Types
 import Graphics.Vty.Input.Classify.Parse
 
-import Control.Monad.Trans.Maybe
 import Control.Monad.State
 import Data.List (isPrefixOf)
 import Data.Maybe (catMaybes)

--- a/src/Graphics/Vty/Input/Paste.hs
+++ b/src/Graphics/Vty/Input/Paste.hs
@@ -1,0 +1,46 @@
+-- | This module provides bracketed paste support as described at
+--
+-- http://cirw.in/blog/bracketed-paste
+module Graphics.Vty.Input.Paste
+    ( parseBracketedPaste
+    , bracketedPasteStarted
+    , bracketedPasteFinished
+    ) where
+
+import Graphics.Vty.Input.Events
+import Graphics.Vty.Input.Classify.Types
+
+import Data.List (isPrefixOf, isInfixOf)
+
+bracketedPasteStart :: String
+bracketedPasteStart = "\ESC[200~"
+
+bracketedPasteEnd :: String
+bracketedPasteEnd = "\ESC[201~"
+
+-- | Does the input start a bracketed paste?
+bracketedPasteStarted :: String -> Bool
+bracketedPasteStarted = isPrefixOf bracketedPasteStart
+
+-- | Does the input contain a complete bracketed paste?
+bracketedPasteFinished :: String -> Bool
+bracketedPasteFinished = isInfixOf bracketedPasteEnd
+
+-- | Parse a bracketed paste. This should only be called on a string if
+-- both 'bracketedPasteStarted' and 'bracketedPasteFinished' return
+-- 'True'.
+parseBracketedPaste :: String -> KClass
+parseBracketedPaste s =
+    let (p, rest) = takeUntil (drop (length bracketedPasteStart) s) bracketedPasteEnd
+        rest' = if bracketedPasteEnd `isPrefixOf` rest
+                then drop (length bracketedPasteEnd) rest
+                else rest
+    in Valid (EvPaste p) rest'
+
+takeUntil :: (Eq a) => [a] -> [a] -> ([a],[a])
+takeUntil [] _ = ([], [])
+takeUntil cs sub
+  | length cs < length sub      = (cs, [])
+  | take (length sub) cs == sub = ([], drop (length sub) cs)
+  | otherwise                   = let (pre, suf) = takeUntil (tail cs) sub
+                                  in (head cs:pre, suf)

--- a/vty.cabal
+++ b/vty.cabal
@@ -98,6 +98,7 @@ library
                        Graphics.Vty.Input.Classify.Parse
                        Graphics.Vty.Input.Loop
                        Graphics.Vty.Input.Mouse
+                       Graphics.Vty.Input.Paste
                        Graphics.Vty.Input.Terminfo
                        Graphics.Vty.PictureToSpans
                        Graphics.Vty.Span


### PR DESCRIPTION
For details, see http://cirw.in/blog/bracketed-paste

This change adds a new Event constructor,

  EvPaste String

to deliver the contents of a paste to the application.  The constructor
provides a String instead of Text as originally suggested because I
wanted to punt on encoding issues and let the application deal with
that.

This change has been tested under tmux, Terminal.app, and iTerm2. A
development build of GNU screen also supports this paste mode (provided
you set TERM to "xterm" to force Vty to use the XtermColor driver for
screen). The mode has apparently been supported for a few years, but
I couldn't get the latest stable build in Homebrew (4.03.01) to work
in this mode so my only testing with GNU Screen was with git HEAD
(8d677e73).  It's possible the original patch didn't actually work but
interim refactorings fixed it.